### PR TITLE
for each memory allocation, obtain stack trace (rather than just the call site)

### DIFF
--- a/preload.c
+++ b/preload.c
@@ -33,13 +33,13 @@ static struct chunk chunks[1 << CHUNK_BITS];
 
 static void get_callstack(void **stack, void **frame)
 {
-    void *stack_end = (void *)(((uintptr_t)frame + 4095) / 4096 * 4096);
+    void **stack_end = (void **)(((uintptr_t)frame + 4095) / 4096 * 4096);
 
     for (size_t i = 0; i < STACK_DEPTH; ++i) {
         stack[i] = frame[1];
         /* check bounds */
         void **next_frame = (void **)*frame;
-        if (!(frame < next_frame && (void *)(next_frame + 1) < stack_end))
+        if (!(frame < next_frame && next_frame < stack_end + 1))
             break;
         frame = next_frame;
     }

--- a/preload.c
+++ b/preload.c
@@ -115,12 +115,7 @@ void *malloc(size_t sz)
         return NULL;
 
     void *callers[STACK_DEPTH] = {};
-
-    {
-        void *rbp;
-        asm("mov %%rbp, %0" : "=r" (rbp));
-        get_callstack(callers, rbp);
-    }
+    get_callstack(callers, __builtin_frame_address(0));
 
     struct callsite *cs = &callsites[hash(callers, STACK_DEPTH, CALLSITE_BITS)];
 


### PR DESCRIPTION
For each memory allocation, the code obtains at most 4 levels of stack trace, by tracking the frames using the rbp register.

To avoid crashes due to reading rbp register used for other purposes, the code stops tracking if the rbp points to another 4K page than where the trace started. Ideally we should be calling `pthread_attr_getstack` to exact boundary, but that is going to be hard considering that leaktrace is a LD_PRELOAD library. Hence the current approach, in hope that we'd have fair chance of obtaining 4 levels of stack trace.

Note also that the stack trace can be collected only from the programs that were compiled with `-fno-omit-frame-pointer` compile option.